### PR TITLE
feat: parse failures from runner output

### DIFF
--- a/examples/calculator/generated/bun/8_bit.test.ts
+++ b/examples/calculator/generated/bun/8_bit.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "bun:test";
 
-const MAX_VALUE = 2**8 - 1;
+const MAX_VALUE = 2 ** 8 - 1;
 
 function add(a: number, b: number): number {
   return (a + b) % (MAX_VALUE + 1);
@@ -21,9 +21,9 @@ describe("8bit", () => {
     });
 
     test("product", () => {
-      expect(multiply(2, 3)).toBe(6);
+      // Intentional fail
+      expect(multiply(2, 3)).toBe(5);
     });
-
   });
 
   describe("add", () => {
@@ -36,7 +36,5 @@ describe("8bit", () => {
     test("sum", () => {
       expect(add(2, 3)).toBe(5);
     });
-
   });
-
 });

--- a/examples/calculator/polytest.toml
+++ b/examples/calculator/polytest.toml
@@ -5,7 +5,8 @@ out_dir = "./generated/pytest"
 
 [runner.pytest]
 command = "pytest"
-args = ["-v", "--color=yes"]
+args = ["-v"]
+fail_regex_template = "{{ file_name }}::test_{{ test_name }} FAILED"
 
 [target.bun]
 out_dir = "./generated/bun"
@@ -13,6 +14,7 @@ out_dir = "./generated/bun"
 [runner.bun]
 command = "bun"
 args = ["test"]
+fail_regex_template = "TODO"
 
 [suite.8bit]
 groups = ["add", "multiply"]

--- a/examples/calculator/polytest.toml
+++ b/examples/calculator/polytest.toml
@@ -3,7 +3,7 @@ name = "calculator example"
 [target.pytest]
 out_dir = "./generated/pytest"
 
-[runner.pytest]
+[target.pytest.runner]
 command = "pytest"
 args = ["-v"]
 fail_regex_template = '{{ file_name }}::test_{{ test_name }} FAILED'
@@ -12,7 +12,7 @@ pass_regex_template = '{{ file_name }}::test_{{ test_name }} PASSED'
 [target.bun]
 out_dir = "./generated/bun"
 
-[runner.bun]
+[target.bun.runner]
 command = "bun"
 args = ["test"]
 fail_regex_template = '\(fail\) {{ suite_name }} > {{ group_name }} > {{ test_name }}( \[\d+\.\d+ms])*$'

--- a/examples/calculator/polytest.toml
+++ b/examples/calculator/polytest.toml
@@ -29,3 +29,17 @@ group = "multiply"
 
 [test.product_overflow]
 group = "multiply"
+
+[target.custom_pytest]
+out_dir = "./generated/custom_pytest"
+
+suite_file_name_template = "test_{{ suite.name | convert_case('Snake') }}.py"
+test_regex_template = "def test_{{ name | convert_case('Snake') }}\\("
+
+template_dir = "./templates/custom_pytest"
+
+[target.custom_pytest.runner]
+fail_regex_template = "{{ file_name }}::test_{{ test_name }} FAILED"
+pass_regex_template = "{{ file_name }}::test_{{ test_name }} PASSED"
+command = "pytest"
+args = ["-v"]

--- a/examples/calculator/polytest.toml
+++ b/examples/calculator/polytest.toml
@@ -6,7 +6,8 @@ out_dir = "./generated/pytest"
 [runner.pytest]
 command = "pytest"
 args = ["-v"]
-fail_regex_template = "{{ file_name }}::test_{{ test_name }} FAILED"
+fail_regex_template = '{{ file_name }}::test_{{ test_name }} FAILED'
+pass_regex_template = '{{ file_name }}::test_{{ test_name }} PASSED'
 
 [target.bun]
 out_dir = "./generated/bun"
@@ -14,7 +15,8 @@ out_dir = "./generated/bun"
 [runner.bun]
 command = "bun"
 args = ["test"]
-fail_regex_template = "TODO"
+fail_regex_template = '\(fail\) {{ suite_name }} > {{ group_name }} > {{ test_name }}( \[\d+\.\d+ms])*$'
+pass_regex_template = '\(pass\) {{ suite_name }} > {{ group_name }} > {{ test_name }}( \[\d+\.\d+ms])*$'
 
 [suite.8bit]
 groups = ["add", "multiply"]

--- a/examples/calculator/polytest.toml
+++ b/examples/calculator/polytest.toml
@@ -3,20 +3,8 @@ name = "calculator example"
 [target.pytest]
 out_dir = "./generated/pytest"
 
-[target.pytest.runner]
-command = "pytest"
-args = ["-v"]
-fail_regex_template = '{{ file_name }}::test_{{ test_name }} FAILED'
-pass_regex_template = '{{ file_name }}::test_{{ test_name }} PASSED'
-
 [target.bun]
 out_dir = "./generated/bun"
-
-[target.bun.runner]
-command = "bun"
-args = ["test"]
-fail_regex_template = '\(fail\) {{ suite_name }} > {{ group_name }} > {{ test_name }}( \[\d+\.\d+ms])*$'
-pass_regex_template = '\(pass\) {{ suite_name }} > {{ group_name }} > {{ test_name }}( \[\d+\.\d+ms])*$'
 
 [suite.8bit]
 groups = ["add", "multiply"]

--- a/examples/calculator/templates/custom_pytest/group.py.jinja
+++ b/examples/calculator/templates/custom_pytest/group.py.jinja
@@ -1,0 +1,3 @@
+
+
+# Polytest Group: {{ group.name }}

--- a/examples/calculator/templates/custom_pytest/suite.py.jinja
+++ b/examples/calculator/templates/custom_pytest/suite.py.jinja
@@ -1,0 +1,3 @@
+import pytest
+
+# Polytest Suite: {{ suite.name }}

--- a/examples/calculator/templates/custom_pytest/test.py.jinja
+++ b/examples/calculator/templates/custom_pytest/test.py.jinja
@@ -1,0 +1,6 @@
+
+
+@pytest.mark.group_{{ group_name | convert_case('Snake') }}
+def test_{{ test.name | convert_case('Snake') }}():
+    """{{ test.desc }}"""
+    raise Exception("TEST NOT IMPLEMENTED")

--- a/examples/custom_targets/polytest.toml
+++ b/examples/custom_targets/polytest.toml
@@ -4,10 +4,6 @@ name = "custom targets example"
 [target.pytest]
 out_dir = "./generated/pytest"
 
-[target.pytest.runner]
-command = "pytest"
-args = ["-v"]
-
 # A custom target must define either of the following sets of options:
 # 
 # For test generation targets, which may have multiple suite files that are updated each time `polytest generate` is ran:

--- a/examples/custom_targets/polytest.toml
+++ b/examples/custom_targets/polytest.toml
@@ -4,7 +4,7 @@ name = "custom targets example"
 [target.pytest]
 out_dir = "./generated/pytest"
 
-[runner.pytest]
+[target.pytest.runner]
 command = "pytest"
 args = ["-v"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,7 +508,7 @@ fn main() -> Result<()> {
         Commands::Validate(validate) => {
             let targets = validate
                 .target
-                .unwrap_or(vec!["pytest".to_string(), "bun".to_string()]);
+                .unwrap_or(config_meta.config.targets.keys().cloned().collect());
 
             for target in targets {
                 validate_target(&config_meta, &target, &env)?;
@@ -518,9 +518,13 @@ fn main() -> Result<()> {
             let mut statuses = IndexMap::<String, ExitStatus>::new();
             let mut outputs = HashMap::<String, String>::new();
 
-            let target_ids = run
-                .target
-                .unwrap_or(vec!["pytest".to_string(), "bun".to_string()]);
+            // If targets are specified via CLI, use the targets that have a runner defined
+            let target_ids: Vec<String> = run.target.unwrap_or(
+                (&config_meta.config.targets)
+                    .into_iter()
+                    .filter_map(|(id, config)| config.runner.as_ref().and(Some(id.clone())))
+                    .collect(),
+            );
 
             let targets: Result<Vec<Target>> = target_ids
                 .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ impl Target {
                 return Ok(Self {
                     id: id.to_string(),
                     test_regex_template: Some(
-                        "def test_{{ name | convert_case('Snake') }}".to_string(),
+                        r"(?m)def test_{{ name | convert_case('Snake') }}\(".to_string(),
                     ),
                     plan_file_name_template: None,
                     suite_file_name_template: Some(
@@ -163,7 +163,7 @@ impl Target {
             "bun" => {
                 return Ok(Self {
                     id: id.to_string(),
-                    test_regex_template: Some("test\\(\"{{ name }}".to_string()),
+                    test_regex_template: Some(r#"(?m)test\("{{ name }}","#.to_string()),
                     plan_file_name_template: None,
                     suite_file_name_template: Some(
                         "{{ suite.name | convert_case('Snake') }}.test.ts".to_string(),
@@ -203,7 +203,10 @@ impl Target {
 
         let mut target = Self {
             id: id.to_string(),
-            test_regex_template: config.test_regex_template.to_owned(),
+            test_regex_template: config
+                .test_regex_template
+                .clone()
+                .map(|t| "(?m)".to_owned() + t.as_str()),
             out_dir: config_root.join(&config.out_dir),
             suite_file_name_template: config.suite_file_name_template.clone(),
             plan_file_name_template: config.plan_file_name_template.clone(),


### PR DESCRIPTION
TODO:

- [x] Add a --no-parse flag
- [x] Add a way to map runners to targets
- [x] Add default runners
- [x] Don't hardcode default runners and instead parse from config
- [x] Add custom runner to an example 