### PR TITLE
feat: pass runner commands as strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "minijinja",
  "regex",
  "serde",
+ "shlex",
  "toml",
 ]
 
@@ -312,6 +313,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ regex = "1.11.1"
 
 # Used to easily deserialize the TOML configuration file
 serde = { version = "1.0.216", features = ["derive"] }
+shlex = "1.3.0"
 
 # Used to parse the TOML configuration file
 toml = "0.8.19"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,11 +154,7 @@ See [templates documentation](./templates.md) for more information on the expect
 
 #### command
 
-The `command` field is used to define the command to run the test. This should just be the name of the executable.
-
-#### args
-
-The `args` field is used to define the arguments to pass to the test command.
+The `command` field is used to define the command to run the test.
 
 #### fail_regex_template
 

--- a/examples/shapes/polytest.toml
+++ b/examples/shapes/polytest.toml
@@ -84,8 +84,7 @@ template_dir = "./templates/minitest_unit"
 fail_regex_template = "Test{{ suite_name | convert_case('Pascal') }}#test_{{ test_name }} = \\d+\\.\\d+ s = (F|E)"
 pass_regex_template = "Test{{ suite_name | convert_case('Pascal') }}#test_{{ test_name }} = \\d+\\.\\d+ s = \\."
 
-command = "bundle"
-args = ["exec", "rake", "test", "A='--verbose'"]
+command = "bundle exec rake test A='--verbose'"
 
 # Custom Document
 


### PR DESCRIPTION
use shlex to parse a user defined string into shell args that can be passed to duct. Main driver is a better ux