### PR TITLE
fix: fixes casing of version strings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,20 +65,26 @@ impl ConfigMeta {
                         cargo_parts.len()
                     );
                 }
-                
-                let config_major = config_parts[0].parse::<u32>()
-                    .with_context(|| format!("Invalid MAJOR version component: '{}'", config_parts[0]))?;
-                let config_minor = config_parts[1].parse::<u32>()
-                    .with_context(|| format!("Invalid MINOR version component: '{}'", config_parts[1]))?;
-                let config_patch = config_parts[2].parse::<u32>()
-                    .with_context(|| format!("Invalid PATCH version component: '{}'", config_parts[2]))?;
-                
-                let cargo_major = cargo_parts[0].parse::<u32>()
-                    .with_context(|| format!("Invalid MAJOR version in Cargo.toml: '{}'", cargo_parts[0]))?;
-                let cargo_minor = cargo_parts[1].parse::<u32>()
-                    .with_context(|| format!("Invalid MINOR version in Cargo.toml: '{}'", cargo_parts[1]))?;
-                let cargo_patch = cargo_parts[2].parse::<u32>()
-                    .with_context(|| format!("Invalid PATCH version in Cargo.toml: '{}'", cargo_parts[2]))?;
+
+                let config_major = config_parts[0].parse::<u32>().with_context(|| {
+                    format!("Invalid MAJOR version component: '{}'", config_parts[0])
+                })?;
+                let config_minor = config_parts[1].parse::<u32>().with_context(|| {
+                    format!("Invalid MINOR version component: '{}'", config_parts[1])
+                })?;
+                let config_patch = config_parts[2].parse::<u32>().with_context(|| {
+                    format!("Invalid PATCH version component: '{}'", config_parts[2])
+                })?;
+
+                let cargo_major = cargo_parts[0].parse::<u32>().with_context(|| {
+                    format!("Invalid MAJOR version in Cargo.toml: '{}'", cargo_parts[0])
+                })?;
+                let cargo_minor = cargo_parts[1].parse::<u32>().with_context(|| {
+                    format!("Invalid MINOR version in Cargo.toml: '{}'", cargo_parts[1])
+                })?;
+                let cargo_patch = cargo_parts[2].parse::<u32>().with_context(|| {
+                    format!("Invalid PATCH version in Cargo.toml: '{}'", cargo_parts[2])
+                })?;
 
                 // Check MAJOR.MINOR match exactly
                 if config_major != cargo_major || config_minor != cargo_minor {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,12 +1,18 @@
 use color_eyre::eyre::{eyre, Context, ContextCompat, Result};
 use convert_case::{Case, Casing};
+use regex::Regex;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::parsing::{find_suite, find_test, get_group_comment, get_groups, get_suite_chunk};
 use crate::runner::Runner;
 use crate::target::Target;
 use crate::ConfigMeta;
 use crate::{document::Document, group::Group, suite::Suite, test::Test};
+
+// Regex to fix version patterns like v_1, V_2 back to v1, V2
+// This is needed because convert_case treats letter-to-number transitions as word boundaries
+static VERSION_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"([vV])_(\d+)").unwrap());
 
 fn case_from_str(s: &str) -> Result<Case> {
     match s {
@@ -36,9 +42,11 @@ fn case_from_str(s: &str) -> Result<Case> {
 }
 
 fn convert_case_filter(input: &str, case: &str) -> String {
-    input.to_case(case_from_str(case).unwrap_or_else(|e| {
+    let result = input.to_case(case_from_str(case).unwrap_or_else(|e| {
         panic!("failed to convert case: {}", e);
-    }))
+    }));
+    // Fix version patterns like v_1, V_2 back to v1, V2 (preserving case)
+    VERSION_PATTERN.replace_all(&result, "$1$2").to_string()
 }
 
 pub fn insert_after_keyword(original: &str, to_insert: &str, keyword: &str) -> String {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,18 +1,12 @@
 use color_eyre::eyre::{eyre, Context, ContextCompat, Result};
-use convert_case::{Case, Casing};
-use regex::Regex;
+use convert_case::{Boundary, Case, Converter};
 use std::path::Path;
-use std::sync::LazyLock;
 
 use crate::parsing::{find_suite, find_test, get_group_comment, get_groups, get_suite_chunk};
 use crate::runner::Runner;
 use crate::target::Target;
 use crate::ConfigMeta;
 use crate::{document::Document, group::Group, suite::Suite, test::Test};
-
-// Regex to fix version patterns like v_1, V_2 back to v1, V2
-// This is needed because convert_case treats letter-to-number transitions as word boundaries
-static VERSION_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"([vV])_(\d+)").unwrap());
 
 fn case_from_str(s: &str) -> Result<Case> {
     match s {
@@ -42,11 +36,21 @@ fn case_from_str(s: &str) -> Result<Case> {
 }
 
 fn convert_case_filter(input: &str, case: &str) -> String {
-    let result = input.to_case(case_from_str(case).unwrap_or_else(|e| {
+    let target_case = case_from_str(case).unwrap_or_else(|e| {
         panic!("failed to convert case: {}", e);
-    }));
-    // Fix version patterns like v_1, V_2 back to v1, V2 (preserving case)
-    VERSION_PATTERN.replace_all(&result, "$1$2").to_string()
+    });
+
+    // Use default boundaries but exclude letter-to-digit transitions (UpperDigit, LowerDigit)
+    // This prevents "v1" from becoming "v_1" in snake_case
+    let boundaries: Vec<Boundary> = Boundary::defaults()
+        .into_iter()
+        .filter(|b| !Boundary::letter_digit().contains(b))
+        .collect();
+
+    Converter::new()
+        .set_boundaries(&boundaries)
+        .to_case(target_case)
+        .convert(input)
 }
 
 pub fn insert_after_keyword(original: &str, to_insert: &str, keyword: &str) -> String {
@@ -532,5 +536,29 @@ impl Renderer {
                 test_name => minijinja::Value::from(&test.name),
             })
             .context(format!("failed to render fail regex for {}", target_runner))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_case_filter;
+
+    #[test]
+    fn convert_case_filter_handles_edge_cases() {
+        let cases = [
+            ("v1", "Snake", "v1"),                  // letter-digit boundary preserved
+            ("testV1", "Snake", "test_v1"),         // camel to snake with digit
+            ("HelloWorld", "Snake", "hello_world"), // standard camel to snake
+            ("hello_world", "Camel", "helloWorld"), // snake to camel
+            ("version2Release", "Snake", "version2_release"), // digit-to-letter boundary
+        ];
+
+        for (input, case, expected) in cases {
+            assert_eq!(
+                convert_case_filter(input, case),
+                expected,
+                "{input:?} | {case}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Addresses an edge case where the `convert_case` crate incorrectly transforms version strings like "v_1" into "V_1".
This change introduces a regular expression to correct these patterns, ensuring that version strings are properly cased as "v1".

Noticed this as part of regenerating tests for algod in py utils, many tests with v2 prefix were generated with filenames where v_2 is split 